### PR TITLE
Hide from NodeGroup dropdown

### DIFF
--- a/Nodes/ShaderNodeCompare.py
+++ b/Nodes/ShaderNodeCompare.py
@@ -10,19 +10,19 @@
 import bpy
 from ShaderNodeBase import ShaderNodeCompact
 
-class ShaderNodeCompare(ShaderNodeCompact):
+class ShaderNodeCompare(bpy.types.ShaderNodeCustomGroup, ShaderNodeCompact):
 
     bl_name='ShaderNodeCompare'
     bl_label='Compare'
     bl_icon='NONE'
-                        
+
     def init(self, context):
         name=self.bl_name + '_nodetree'
         if bpy.data.node_groups.find(name)>-1:
             self.node_tree=bpy.data.node_groups[name]
             for ind in [0,2,3,4,5]:
                 self.outputs[ind].enabled=False
-        else:    
+        else:
             self.node_tree=bpy.data.node_groups.new(name, 'ShaderNodeTree')
             if hasattr(self.node_tree, 'is_hidden'):
                 self.node_tree.is_hidden=True
@@ -78,14 +78,14 @@ class ShaderNodeCompare(ShaderNodeCompact):
         if self.operation=='Similar To':
             self.inputs[0].enabled=True
         else:
-            self.inputs[0].enabled=False  
+            self.inputs[0].enabled=False
         for i in self.outputs:
             if i.is_linked:
                 for link in i.links:
                     outs.append(link.to_socket)
                     context.space_data.edit_tree.links.remove(link)
             i.enabled=False
-        ind=self.bl_rna.properties['operation'].enum_items.find(self.operation)               
+        ind=self.bl_rna.properties['operation'].enum_items.find(self.operation)
         self.outputs[ind].enabled=True
         for ln in outs:
             context.space_data.edit_tree.links.new(self.outputs[ind], ln)
@@ -97,13 +97,13 @@ class ShaderNodeCompare(ShaderNodeCompact):
     def free(self):
         if self.node_tree.users==1:
             bpy.data.node_groups.remove(self.node_tree, do_unlink=True)
-        
+
     def draw_buttons(self, context, layout):
         layout.prop(self, 'operation', text='')
-        
+
     def draw_label(self):
         idx=self.bl_rna.properties['operation'].enum_items.find(self.operation)
         return self.bl_rna.properties['operation'].enum_items[idx].name
-        
+
     def draw_menu():
         return 'SH_NEW_CONVERTOR' , 'Converter'

--- a/Nodes/ShaderNodeDisplacementBake.py
+++ b/Nodes/ShaderNodeDisplacementBake.py
@@ -10,23 +10,23 @@
 import bpy
 from ShaderNodeBase import ShaderNodeCompact
 
-class ShaderNodeDisplacementBake(ShaderNodeCompact):
-    
+class ShaderNodeDisplacementBake(bpy.types.ShaderNodeCustomGroup, ShaderNodeCompact):
+
     bl_name='ShaderNodeDisplacementBake'
     bl_label='Displacement Bake'
     bl_icon='NONE'
-    
+
     axis_items=(('X', 'X', 'POS_X'),
             ('-X', '-X', 'NEG_X'),
             ('Y', 'Y', 'POS_Y'),
             ('-Y', '-Y', 'NEG_Y'),
             ('Z', 'Z', 'POS_Z'),
             ('-Z', '-Z', 'NEG_Z'))
-    
+
     display_items=(('xyz','xyz', 'xyz'),('fas', 'fas', 'fas'))
-    
+
     output_items=(('0','Position','Position'),('1','Scalar Displacement','Scalar Displacement'), ('2','Object Vector Displacement','World Displacement'), ('3','Tangent Vector Displacement','Tangent Displacement'))
-    
+
     def enumupdate(self,context):
         def filteraxis(axis):
             if axis=='X':
@@ -38,20 +38,20 @@ class ShaderNodeDisplacementBake(ShaderNodeCompact):
             elif axis=='Z':
                 if int((self.zenum-1)/2%2)==1:
                     axis = '-' + axis
-            return axis    
+            return axis
         axis_order=(('Y','Z','X'),('Z','Y','X'),('Y','X','Z'),('X','Y','Z'),('Z','X','Y'),('X','Z','Y'))
         seq=axis_order[int(self.zenum/8%6)]
         self.axis_X=filteraxis(seq[0])
         self.axis_Y=filteraxis(seq[1])
         self.axis_Z=filteraxis(seq[2])
-           
+
     def axisupdate(self, context):
         if (self.axis_X.lstrip('-')==self.axis_Y.lstrip('-')) or (self.axis_X.lstrip('-')==self.axis_Z.lstrip('-')) or (self.axis_Y.lstrip('-')==self.axis_Z.lstrip('-')):
             return
         for i, cmp in enumerate([self.axis_X, self.axis_Y, self.axis_Z]):
             if self.outvalue=='2':
                 fromsocket=self.node_tree.nodes["WorldSep"].outputs[i]
-            elif self.outvalue=='3':    
+            elif self.outvalue=='3':
                 fromsocket=self.node_tree.nodes[cmp.lstrip('-')+'Dot'].outputs[1]
             tosocket=self.node_tree.nodes['Combine XYZ'].inputs[i]
             if tosocket.is_linked:
@@ -64,14 +64,14 @@ class ShaderNodeDisplacementBake(ShaderNodeCompact):
 
     def uvmapupdate(self, context):
         self.node_tree.nodes['Tangent'].uv_map=self.uvmap
-    
+
     def outputupdate(self, context):
         nexit=self.node_tree.nodes["Emission"]
         if nexit.inputs[0].is_linked:
             self.node_tree.links.remove(nexit.inputs[0].links[0])
         if nexit.inputs[1].is_linked:
             self.node_tree.links.remove(nexit.inputs[1].links[0])
-        
+
         if self.outvalue=='0':
             if self.inputs[0].is_linked:
                 context.space_data.edit_tree.links.remove(self.inputs[0].links[0])
@@ -90,18 +90,18 @@ class ShaderNodeDisplacementBake(ShaderNodeCompact):
             else:
                 input=self.node_tree.nodes['Multiply'].outputs[0]
                 self.axisupdate(context)
-            self.node_tree.links.new(input , nexit.inputs[0])                
+            self.node_tree.links.new(input , nexit.inputs[0])
             self.node_tree.links.new(self.node_tree.nodes['Group Input'].outputs[1], nexit.inputs[1])
 
 
     axis_X: bpy.props.EnumProperty(default = 'X', items = axis_items, name = "X_list", update = axisupdate)
     axis_Y: bpy.props.EnumProperty(default = 'Y',items = axis_items, name = "Y_list", update = axisupdate)
-    axis_Z: bpy.props.EnumProperty(default = 'Z',items = axis_items, name = "Z_list", update = axisupdate)                                                 
+    axis_Z: bpy.props.EnumProperty(default = 'Z',items = axis_items, name = "Z_list", update = axisupdate)
     zenum: bpy.props.IntProperty(default = 25, name = 'FlipAndSwitch', min = 1, max = 48, update = enumupdate)
     uvmap: bpy.props.StringProperty(name = 'UV Map',default = '', update = uvmapupdate)
     display: bpy.props.EnumProperty(default = 'FlipAndSwitch' , items = (('XYZ','XYZ', 'Custom XYZ'),('FlipAndSwitch', 'ZBrush', 'Zbrush Compatible'))) # to be added : , ('Presets', 'Presets', 'Presets')
     outvalue: bpy.props.EnumProperty(default = '0' , items = output_items, name = 'Output', update=outputupdate)
-    
+
     def init(self, context):
         self.width = 200
         self.node_tree = bpy.data.node_groups.new(self.bl_name+'nodetree', 'ShaderNodeTree')
@@ -147,7 +147,7 @@ class ShaderNodeDisplacementBake(ShaderNodeCompact):
         if self.outvalue=='2':
             row=layout.row(align=True)
             row.alert=(self.axis_X.lstrip('-')==self.axis_Y.lstrip('-') or self.axis_X.lstrip('-')==self.axis_Z.lstrip('-'))
-            row.prop(self, 'axis_X', text='')  
+            row.prop(self, 'axis_X', text='')
             row.alert=(self.axis_Y.lstrip('-')==self.axis_X.lstrip('-') or self.axis_Y.lstrip('-')==self.axis_Z.lstrip('-'))
             row.prop(self, 'axis_Y', text='')
             row.alert=(self.axis_Z.lstrip('-')==self.axis_X.lstrip('-') or self.axis_Z.lstrip('-')==self.axis_Y.lstrip('-'))
@@ -159,23 +159,23 @@ class ShaderNodeDisplacementBake(ShaderNodeCompact):
             elif self.display=='XYZ':
                 row=layout.row(align=True)
                 row.alert=(self.axis_X.lstrip('-')==self.axis_Y.lstrip('-') or self.axis_X.lstrip('-')==self.axis_Z.lstrip('-'))
-                row.prop(self, 'axis_X', text='')  
+                row.prop(self, 'axis_X', text='')
                 row.alert=(self.axis_Y.lstrip('-')==self.axis_X.lstrip('-') or self.axis_Y.lstrip('-')==self.axis_Z.lstrip('-'))
                 row.prop(self, 'axis_Y', text='')
                 row.alert=(self.axis_Z.lstrip('-')==self.axis_X.lstrip('-') or self.axis_Z.lstrip('-')==self.axis_Y.lstrip('-'))
                 row.prop(self, 'axis_Z', text='')
             row=layout.row()
-            row.prop_search(self, "uvmap", context.active_object.data, "uv_layers", icon='GROUP_UVS')        
+            row.prop_search(self, "uvmap", context.active_object.data, "uv_layers", icon='GROUP_UVS')
 
     def draw_buttons_ext(self, context, layout):
         if self.outvalue=='3':
             layout.prop(self, 'display', text='Interface:')
-            
+
     def copy(self, node):
-        self.node_tree=node.node_tree.copy()      
-     
+        self.node_tree=node.node_tree.copy()
+
     def free(self):
-        bpy.data.node_groups.remove(self.node_tree)    
+        bpy.data.node_groups.remove(self.node_tree)
 
     def draw_menu():
         return 'SH_NEW_BakeTools' , 'Bake Nodes'

--- a/Nodes/ShaderNodeInterpolate.py
+++ b/Nodes/ShaderNodeInterpolate.py
@@ -10,12 +10,12 @@
 import bpy
 from ShaderNodeBase import ShaderNodeCompact
 
-class ShaderNodeInterpolate(ShaderNodeCompact):
+class ShaderNodeInterpolate(bpy.types.ShaderNodeCustomGroup, ShaderNodeCompact):
 
     bl_name='ShaderNodeInterpolate'
     bl_label='Interpolate'
     bl_icon='NONE'
-    
+
     interpolation_list=[('LIN', 'Lerp', 'Lerp'),
                         ('SMTS', 'SmoothStep', 'SmoothStep'),
                         ('SMTRS', 'SmootherStep', 'SmootherStep'),
@@ -25,7 +25,7 @@ class ShaderNodeInterpolate(ShaderNodeCompact):
                         ('ISIN', 'Invert Sine', 'InvSine'),
                         ('COS', 'Cos', 'CosPi'),
                         ('CTMR', 'Catmull-Rom', 'Catmull-Rom')]
-    
+
     def interpol_update(self, context):
         out=self.node_tree.nodes['MIXENTRY'].inputs[0]
         if out.is_linked:
@@ -55,10 +55,10 @@ class ShaderNodeInterpolate(ShaderNodeCompact):
             self.inputs[2].enabled=True
             self.inputs[3].enabled=True
             src='nodes["CATMULLROM"].outputs[0]'
-        self.addLinks([(src, out)])    
-    
-    
-    interpolation: bpy.props.EnumProperty(name='interpolation', items=interpolation_list, default='LIN', update=interpol_update)                    
+        self.addLinks([(src, out)])
+
+
+    interpolation: bpy.props.EnumProperty(name='interpolation', items=interpolation_list, default='LIN', update=interpol_update)
 
 
     def init(self, context):
@@ -177,18 +177,17 @@ class ShaderNodeInterpolate(ShaderNodeCompact):
             ('inputs[0]', 'nodes["MIXENTRY"].inputs[0]')])
 
     def copy(self, node):
-        self.node_tree=node.node_tree.copy()      
-     
+        self.node_tree=node.node_tree.copy()
+
     def free(self):
-        bpy.data.node_groups.remove(self.node_tree, do_unlink=True)  
+        bpy.data.node_groups.remove(self.node_tree, do_unlink=True)
 
     def draw_buttons(self, context, layout):
         layout.prop(self, "interpolation", text='')
-    
+
     def draw_label(self):
         idx=self.bl_rna.properties['interpolation'].enum_items.find(self.interpolation)
         return self.bl_rna.properties['interpolation'].enum_items[idx].name
-        
-    def draw_menu():
-        return 'SH_NEW_CONVERTOR' , 'Converter'    
 
+    def draw_menu():
+        return 'SH_NEW_CONVERTOR' , 'Converter'

--- a/Nodes/ShaderNodeLoop.py
+++ b/Nodes/ShaderNodeLoop.py
@@ -9,11 +9,11 @@
 
 import bpy
 
-class ShaderNodeLoop(bpy.types.NodeCustomGroup):
-    
+class ShaderNodeLoop(bpy.types.ShaderNodeCustomGroup):
+
     bl_name='ShaderNodeLoop'
     bl_label='Loop Node'
-    
+
     def nodegroups(self, context):
         nt=context.space_data.edit_tree
         list=[('None','None','None')]
@@ -22,8 +22,8 @@ class ShaderNodeLoop(bpy.types.NodeCustomGroup):
                 ng=nd.node_tree
                 if ng.inputs.get('iterator'):
                     list.append((ng.name, ng.name, ng.name))
-        return list            
-      
+        return list
+
     def __nodeinterface_setup__(self):
         self.node_tree.outputs.clear()
         self.node_tree.inputs.clear()
@@ -36,19 +36,19 @@ class ShaderNodeLoop(bpy.types.NodeCustomGroup):
         for output in bpy.data.node_groups[self.step_nodegroup].outputs:
             self.node_tree.nodes['Group Output'].inputs.new(output.bl_socket_idname, output.name)
             self.node_tree.outputs.new(output.bl_socket_idname, output.name)
-    
+
     def __nodetree_setup__(self):
         self.node_tree.links.clear()
         for node in self.node_tree.nodes:
             if not node.name in ['Group Input','Group Output']:
                 self.node_tree.nodes.remove(node)
         if self.step_nodegroup=='None':
-            return        
+            return
         previousnode=self.node_tree.nodes['Group Input']
         for iter in range(self.iterations):
-            curnode=self.node_tree.nodes.new('ShaderNodeGroup')                    
+            curnode=self.node_tree.nodes.new('ShaderNodeGroup')
             curnode.node_tree=bpy.data.node_groups[self.step_nodegroup]
-            curnode.inputs['iterator'].default_value=iter            
+            curnode.inputs['iterator'].default_value=iter
             for input in curnode.inputs:
                 poutput=previousnode.outputs.get(input.name)
                 if poutput:
@@ -59,36 +59,36 @@ class ShaderNodeLoop(bpy.types.NodeCustomGroup):
                     if poutput:
                         self.node_tree.links.new(poutput, input)
             else:
-                previousnode=curnode        
+                previousnode=curnode
 
     def update_nt(self, context):
         self.__nodeinterface_setup__()
         self.__nodetree_setup__()
-    
+
     def update_it(self, context):
         self.__nodetree_setup__()
-                
-    step_nodegroup: bpy.props.EnumProperty(name="step_nodegroup", items=nodegroups, update=update_nt)    
-    
+
+    step_nodegroup: bpy.props.EnumProperty(name="step_nodegroup", items=nodegroups, update=update_nt)
+
     iterations: bpy.props.IntProperty(name="iterations", min=1, max=63, default=8, update=update_it)
-        
-    
+
+
     def init(self, context):
         self.node_tree=bpy.data.node_groups.new(self.bl_name, 'ShaderNodeTree')
         if hasattr(self.node_tree, 'is_hidden'):
             self.node_tree.is_hidden=True
         self.node_tree.nodes.new('NodeGroupInput')
-        self.node_tree.nodes.new('NodeGroupOutput') 
-    
+        self.node_tree.nodes.new('NodeGroupOutput')
+
     def draw_buttons(self, context, layout):
         row=layout.row()
         row.alert=(self.step_nodegroup=='None')
         row.prop(self, 'step_nodegroup', text='')
         row=layout.row()
         row.prop(self, 'iterations', text='iterations')
-        
+
     def copy(self, node):
         self.node_tree=node.node_tree.copy()
-    
+
     def free(self):
         bpy.data.node_groups.remove(self.node_tree, do_unlink=True)

--- a/Nodes/ShaderNodeNormalBake.py
+++ b/Nodes/ShaderNodeNormalBake.py
@@ -10,7 +10,7 @@
 import bpy
 from ShaderNodeBase import ShaderNodeCompact
 
-class ShaderNodeNormalBake(ShaderNodeCompact):
+class ShaderNodeNormalBake(bpy.types.ShaderNodeCustomGroup, ShaderNodeCompact):
 
     bl_name='ShaderNodeNormalBake'
     bl_label='Normal Bake'
@@ -22,7 +22,7 @@ class ShaderNodeNormalBake(ShaderNodeCompact):
         ('-Y', '-Y', 'NEG_Y'),
         ('Z', 'Z', 'POS_Z'),
         ('-Z', '-Z', 'NEG_Z'))
-    
+
     def axisupdate(self, context):
         if (self.axis_X.lstrip('-')==self.axis_Y.lstrip('-')) or (self.axis_X.lstrip('-')==self.axis_Z.lstrip('-')) or (self.axis_Y.lstrip('-')==self.axis_Z.lstrip('-')):
             return
@@ -35,14 +35,14 @@ class ShaderNodeNormalBake(ShaderNodeCompact):
             tosocket=self.node_tree.nodes['FinalCombine'].inputs[i]
             if tosocket.is_linked:
                 self.node_tree.links.remove(tosocket.links[0])
-            self.node_tree.links.new(fromsocket, tosocket)    
+            self.node_tree.links.new(fromsocket, tosocket)
 
     def uvmapupdate(self, context):
         self.node_tree.nodes['Tangent'].uv_map=self.uvmap
-            
+
     axis_X: bpy.props.EnumProperty(default = 'X', items = axis_items, name = "X_list", update = axisupdate)
     axis_Y: bpy.props.EnumProperty(default = 'Y',items = axis_items, name = "Y_list", update = axisupdate)
-    axis_Z: bpy.props.EnumProperty(default = 'Z',items = axis_items, name = "Z_list", update = axisupdate)                                                 
+    axis_Z: bpy.props.EnumProperty(default = 'Z',items = axis_items, name = "Z_list", update = axisupdate)
     uvmap: bpy.props.StringProperty(name = 'UV Map',default = '', update = uvmapupdate)
 
     def init(self, context):
@@ -64,8 +64,8 @@ class ShaderNodeNormalBake(ShaderNodeCompact):
             ('ShaderNodeSeparateRGB', {'name':'Negative'}),
             ('ShaderNodeSeparateRGB', {'name':'Positive'}),
             ('ShaderNodeCombineRGB', {'name':'FinalCombine', 'inputs[0].default_value':0.000, 'inputs[1].default_value':0.000, 'inputs[2].default_value':0.000}),
-            ('ShaderNodeEmission', {'name':'EmiClosure', 'inputs[1].default_value':1.0})])       
-        self.addInputs([('NodeSocketVector', {'name':'Normal', 'hide_value':True})])        
+            ('ShaderNodeEmission', {'name':'EmiClosure', 'inputs[1].default_value':1.0})])
+        self.addInputs([('NodeSocketVector', {'name':'Normal', 'hide_value':True})])
         self.addOutputs([('NodeSocketShader', {'name':'Tangent'})])
         self.addLinks([('nodes["Geometry"].outputs[1]', 'nodes["CoTangent"].inputs[0]'),
             ('nodes["Tangent"].outputs[0]', 'nodes["CoTangent"].inputs[1]'),
@@ -92,14 +92,14 @@ class ShaderNodeNormalBake(ShaderNodeCompact):
 
     def copy(self, node):
         self.node_tree=node.node_tree.copy()
-    
+
     def free(self):
         bpy.data.node_groups.remove(self.node_tree, do_unlink=True)
-        
+
     def draw_buttons(self, context, layout):
         row=layout.row(align=True)
         row.alert=(self.axis_X.lstrip('-')==self.axis_Y.lstrip('-') or self.axis_X.lstrip('-')==self.axis_Z.lstrip('-'))
-        row.prop(self, 'axis_X', text='')  
+        row.prop(self, 'axis_X', text='')
         row.alert=(self.axis_Y.lstrip('-')==self.axis_X.lstrip('-') or self.axis_Y.lstrip('-')==self.axis_Z.lstrip('-'))
         row.prop(self, 'axis_Y', text='')
         row.alert=(self.axis_Z.lstrip('-')==self.axis_X.lstrip('-') or self.axis_Z.lstrip('-')==self.axis_Y.lstrip('-'))
@@ -108,4 +108,4 @@ class ShaderNodeNormalBake(ShaderNodeCompact):
         row.prop_search(self, "uvmap", context.active_object.data, "uv_layers", icon='GROUP_UVS')
 
     def draw_menu():
-        return 'SH_NEW_BakeTools' , 'Bake Nodes'    
+        return 'SH_NEW_BakeTools' , 'Bake Nodes'

--- a/Nodes/ShaderNodeSwitchFloat.py
+++ b/Nodes/ShaderNodeSwitchFloat.py
@@ -10,7 +10,7 @@
 import bpy
 from ShaderNodeBase import ShaderNodeCompact
 
-class ShaderNodeSwitchFloat(ShaderNodeCompact):
+class ShaderNodeSwitchFloat(bpy.types.ShaderNodeCustomGroup, ShaderNodeCompact):
 
     bl_name='ShaderNodeSwitchFloat'
     bl_label='Switch Float'
@@ -20,7 +20,7 @@ class ShaderNodeSwitchFloat(ShaderNodeCompact):
         name=self.bl_name + '_nodetree'
         if bpy.data.node_groups.find(name)>-1:
             self.node_tree=bpy.data.node_groups[name]
-        else:    
+        else:
             self.node_tree=bpy.data.node_groups.new(name, 'ShaderNodeTree')
             if hasattr(self.node_tree, 'is_hidden'):
                 self.node_tree.is_hidden=True
@@ -48,6 +48,6 @@ class ShaderNodeSwitchFloat(ShaderNodeCompact):
     def free(self):
         if self.node_tree.users==1:
             bpy.data.node_groups.remove(self.node_tree, do_unlink=True)
-            
+
     def draw_menu():
         return 'SH_NEW_CONVERTOR' , 'Converter'

--- a/ShaderNodeBase.py
+++ b/ShaderNodeBase.py
@@ -17,7 +17,7 @@ class ShaderNodeBase(bpy.types.NodeCustomGroup):
         setattr(obj, path, val)                
     
     def setupTree(self, unique=False):
-        name=self.bl_name + '_nodetree'
+        name='.' + self.bl_name + '_nodetree'
         if unique or bpy.data.node_groups.find(name)==-1:
             self.node_tree=bpy.data.node_groups.new(name + '_nodetree', 'ShaderNodeTree')
             self.addNode('NodeGroupInput', {'name':'Group Input'})

--- a/__init__.py
+++ b/__init__.py
@@ -116,7 +116,7 @@ def exportNodetree(nodetree, bl_name, bl_label):
     file=open(filepath, 'w')
     file.write('import bpy\n')
     file.write('from ShaderNodeBase import ShaderNodeBase\n\n')
-    file.write('class ' + bl_name + '(ShaderNodeBase):\n\n')
+    file.write('class ' + bl_name + '(bpy.types.ShaderNodeCustomGroup, ShaderNodeBase):\n\n')
     file.write('    bl_name=\'' + bl_name + '\'\n')
     file.write('    bl_label=\'' + bl_label + '\'\n')
     file.write('    bl_icon=\'NONE\'\n\n')


### PR DESCRIPTION
When you select node group dropdown to switch node groups, the node groups show up with bl_name_nodetree_nodetree(.###) and if you're a heavy user, this can make a lot of clutter in that dropdown making it hard to find your groups.

With a `.` in front, they're hidden away, though still available in python if you want to mess with it.